### PR TITLE
Add `pbzip2` to jdk8-python36 Docker image

### DIFF
--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -3,8 +3,9 @@ FROM adoptopenjdk:8-jdk-hotspot
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git=* \
     openssh-client=* \
-    python3.6=* \
+    pbzip2=* \
     python3-pip=* \
+    python3.6=* \
     unzip=* \
     wget=* \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We use `pbzip2` during our CI tests so we require it in our pipeline
images.