### PR TITLE
Refactor Makefile to push to Dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
-.PHONY: all list
+.PHONY: all list build lint push
 
 DOCKERFILES = $(shell find . -type f -name Dockerfile)
+DOCKER_REPOSITORY = ukhydrographicoffice
+
+DATE = $(shell date '+%Y-%m-%d')
+GIT_COMMIT_HASH = $(shell git rev-parse --short HEAD)
+DOCKER_TAG = $(DATE)-$(GIT_COMMIT_HASH)
 
 all: lint build
 
@@ -9,22 +14,37 @@ all: lint build
 list:
 	@: $(foreach item,$(DOCKERFILES),$(info $(item)))
 
+### Lint
+
+LINT_DONE_FILES = $(subst Dockerfile,.LINT.DONE,$(DOCKERFILES))
+
+lint: $(LINT_DONE_FILES)
+
+%/.LINT.DONE: %/Dockerfile
+	docker run --rm -i hadolint/hadolint < $<
+	@touch $@
+
 ### Build
 
-BUILD_DONE = $(subst Dockerfile,.BUILD.DONE,$(DOCKERFILES))
+BUILD_DONE_FILES = $(subst Dockerfile,.BUILD.DONE,$(DOCKERFILES))
 
-build: $(BUILD_DONE)
+build: $(BUILD_DONE_FILES)
 
 %/.BUILD.DONE: %/Dockerfile
 	docker build $*
 	@touch $@
 
-### Lint
+### Push
 
-LINT_DONE = $(subst Dockerfile,.LINT.DONE,$(DOCKERFILES))
+PUSH_DONE_FILES = $(subst Dockerfile,.PUSH.DONE,$(DOCKERFILES))
 
-lint: $(LINT_DONE)
+push: $(PUSH_DONE_FILES)
 
-%/.LINT.DONE: %/Dockerfile
-	docker run --rm -i hadolint/hadolint < $<
+%/.PUSH.DONE: %/Dockerfile
+	$(eval IMAGE_NAME = $(DOCKER_REPOSITORY)/$(shell basename $*))
+	docker build -t $(IMAGE_NAME) $*
+	docker push $(IMAGE_NAME)
+	$(eval VERSIONED_IMAGE_NAME = $(IMAGE_NAME):$(DOCKER_TAG))
+	docker build -t $(VERSIONED_IMAGE_NAME) $*
+	docker push $(VERSIONED_IMAGE_NAME)
 	@touch $@

--- a/README.md
+++ b/README.md
@@ -2,21 +2,39 @@
 
 ## About
 
-This is a repository to contain various base Docker Images
+This is a repository to contain various Docker Images
 
 Dockerfiles should conform to [best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/)
+
+## How to add a Docker Image
+
+Create a directory and put the Dockerfile in it
+
+Note: The Docker Image will be named the same as the directory
+
+The Makefile will then pick it up and do the rest, that simple!
+
+You can verify it's being picked up by running [`make list`](#List)
 
 ## Makefile
 
 The Makefile searches for directories containing a file named `Dockerfile` and uses those for the subsequent commands
 
-By default running `make` will run [lint](#Lint) [build](#Build)
+By default running `make` will run [lint](#Lint) and [build](#Build)
 
 It has been written to be idempotent so it will consistently fail/succeed
 
+### List
+
+Run using `make list`
+
+Displays the list of Dockerfiles that will be used by other commands
+
+This can be used to verify that a new Dockerfile has been added correctly
+
 ### Lint
 
-Run with `make lint`
+Run using `make lint`
 
 Lints the Dockerfiles for good practices using [hadolint](https://github.com/hadolint/hadolint)
 
@@ -24,8 +42,18 @@ Produces a `.LINT.DONE` file in the same directory as the Dockerfile
 
 ### Build
 
-Run with `make build`
+Run using `make build`
 
 Builds the Docker images, but does not push them
 
 Produces a `.BUILD.DONE` file in the same directory as the Dockerfile
+
+### Push
+
+Run using `make push`
+
+Builds and pushes the Docker images:
+- `{docker repository from Makefile}/{directory}:latest`
+- `{docker repository from Makefile}/{directory}:{git commit hash of HEAD}`
+
+Produces a `.PUSH.DONE` file in the same directory as the Dockerfile

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
     dependsOn:
       - 'lint'
       - 'build'
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     steps:
       - script: docker login -u $(DOCKER_REGISTRY_USERNAME) -p $(DOCKER_REGISTRY_PASSWORD)
       - script: make push

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
   - job: 'publish'
     pool: $(poolName)
     dependsOn:
-      - 'lint'
+      - 'check'
       - 'build'
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,12 +6,34 @@ pr:
     include:
       - '*'
 
-pool:
-  vmImage: 'ubuntu-latest'
+schedules:
+  - cron: '0 7 * * *'
+    displayName: 'Rebuild images for updates'
+    branches:
+      include:
+        - master
+    always: true
 
-steps:
-  - script: make lint
-    displayName: 'Lint'
+variables:
+  poolName: 'ubuntu-latest'
 
-  - script: make build
-    displayName: 'Build'
+jobs:
+  - job: 'check'
+    pool: $(poolName)
+    steps:
+      - script: make lint
+
+  - job: 'build'
+    pool: $(poolName)
+    steps:
+      - script: make build
+
+  - job: 'publish'
+    pool: $(poolName)
+    dependsOn:
+      - 'lint'
+      - 'build'
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')
+    steps:
+      - script: docker login -u $(DOCKER_REGISTRY_USERNAME) -p $(DOCKER_REGISTRY_PASSWORD)
+      - script: make push

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ schedules:
     always: true
 
 variables:
-  poolName: 'ubuntu-latest'
+  poolName: 'UKHO Ubuntu 1804'
 
 jobs:
   - job: 'check'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,21 +15,24 @@ schedules:
     always: true
 
 variables:
-  poolName: 'UKHO Ubuntu 1804'
+  vmImage: 'ubuntu-latest'
 
 jobs:
   - job: 'check'
-    pool: $(poolName)
+    pool:
+      vmImage: $(vmImage)
     steps:
       - script: make lint
 
   - job: 'build'
-    pool: $(poolName)
+    pool:
+      vmImage: $(vmImage)
     steps:
       - script: make build
 
   - job: 'publish'
-    pool: $(poolName)
+    pool:
+      vmImage: $(vmImage)
     dependsOn:
       - 'check'
       - 'build'


### PR DESCRIPTION
* Improve encapsulation by bringing more of the CI/CD into the Makefile
* Maintain minimal dependency on Azure Pipelines by using it as an
orchestrator
* Reduce dependency on Dockerhub by favouring push over pull for images