### PR TITLE
Add image for awscli

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 jdk8-python36/  @UKHO/Atlantis
 terraform-azure-make/ @UKHO/digital-delivery-capability
+awscli/ @UKHO/data-engineering

--- a/awscli/Dockerfile
+++ b/awscli/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.6-slim
+
+RUN pip3 install --upgrade awscli==1.16.291
+
+ENTRYPOINT ["aws"]
+


### PR DESCRIPTION
There is no official `awscli` Docker image for executing commands

The current 'favoured' image available is out of date with the new versions of `awscli`