### PR TITLE
Move download to use github

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,6 @@
 [please]
-version = 14.1.9
+version = 14.1.11
+downloadlocation = https://github.com/thought-machine/please/releases/download/
 
 [python]
 moduledir = third_party.python

--- a/pleasew
+++ b/pleasew
@@ -51,7 +51,7 @@ fi
 # Don't have any builds other than amd64 at the moment.
 ARCH="amd64"
 
-PLEASE_URL="${URL_BASE}/${GOOS}_${ARCH}/${VERSION}/please_${VERSION}.tar.xz"
+PLEASE_URL="${URL_BASE}/v${VERSION}/please_${VERSION}_${GOOS}_${ARCH}.tar.xz"
 DIR="${LOCATION}/${VERSION}"
 # Potentially we could reuse this but it's easier not to really.
 if [ ! -d "$DIR" ]; then


### PR DESCRIPTION
* Increased version to 14.1.11
* Due to recent 524 error.
* Interested to see if we can use github as source of truth.