### PR TITLE
Remove readme push

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,6 +17,6 @@ sh_group(
     deps = [
         push_target
         for target in docker_image_targets
-        for push_target in [f"{target}_push", f"{target}_readme_push"]
+        for push_target in [f"{target}_push"]
     ],
 )


### PR DESCRIPTION
needs a longer look as to what is needed on the agents to run.

this issue is currently blocking image publishing.