### PR TITLE
158165 - adds credential helper for ecr docker image push

### DIFF
--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -18,4 +18,4 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install setuptools==41.6.0 wheel==0.33.6 \
   && pip3 install awscli==1.16.277 \
-  && curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login
+  && curl -L -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login

--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     build-essential=* \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install setuptools==41.6.0 wheel==0.33.6 \
-  && pip3 install awscli==1.16.277 \
+  && pip3 install awscli==1.16.277
 RUN wget -P /usr/local/bin/ https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login

--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     build-essential=* \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install setuptools==41.6.0 wheel==0.33.6 \
-  && pip3 install awscli==1.16.277
-  && wget https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login
+  && pip3 install awscli==1.16.277 \
+  && wget -P /usr/local/bin/ https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login

--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -17,5 +17,5 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
     build-essential=* \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install setuptools==41.6.0 wheel==0.33.6 \
-  && pip3 install awscli==1.16.277
-RUN wget -P /usr/local/bin/ https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login
+  && pip3 install awscli==1.16.277 \
+  && curl -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login

--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -18,3 +18,4 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install setuptools==41.6.0 wheel==0.33.6 \
   && pip3 install awscli==1.16.277
+  && wget https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login

--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -18,4 +18,6 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install setuptools==41.6.0 wheel==0.33.6 \
   && pip3 install awscli==1.16.277 \
-  && curl -L -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login
+  && curl -L -O https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login \
+  && chmod +x ./docker-credential-ecr-login \
+  && mv ./docker-credential-ecr-login /usr/local/bin/

--- a/jdk8-python36/Dockerfile
+++ b/jdk8-python36/Dockerfile
@@ -18,4 +18,4 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
   && rm -rf /var/lib/apt/lists/* \
   && pip3 install setuptools==41.6.0 wheel==0.33.6 \
   && pip3 install awscli==1.16.277 \
-  && wget -P /usr/local/bin/ https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login
+RUN wget -P /usr/local/bin/ https://amazon-ecr-credential-helper-releases.s3.us-east-2.amazonaws.com/0.4.0/linux-amd64/docker-credential-ecr-login


### PR DESCRIPTION
See https://github.com/awslabs/amazon-ecr-credential-helper/releases
This is needed to allow credentials for the gradle jib command in the ais-pipeline to push the docker images to ecr.
