### PR TITLE
Regex should ignore beta versions

### DIFF
--- a/linux/esa-snap7-snappy/Dockerfile
+++ b/linux/esa-snap7-snappy/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    libpython3.6=3.6.10-1+xenial1 \
+    libpython3.6=3.6.11-1+xenial1 \
     openjdk-8-jre-headless=8u252-b09-1~16.04 \
-    python3.6=3.6.10-1+xenial1 \
+    python3.6=3.6.11-1+xenial1 \
     python3-pip=8.1.1-2ubuntu0.4 \
     wget=1.17.1-1ubuntu1.5 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/linux/terraform-azure-make/versions
+++ b/linux/terraform-azure-make/versions
@@ -1,5 +1,5 @@
 #/usr/bin/env bash
 tf=$(curl -s "https://releases.hashicorp.com/terraform/")
-match="\/terraform\/?([^\/]*)\/"
+match="[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}[^-\/]"
 [[ ${tf} =~ ${match} ]]; 
-echo "${BASH_REMATCH[1]}"
+echo "${BASH_REMATCH[0]}"

--- a/linux/terraform-azure-powershell/versions
+++ b/linux/terraform-azure-powershell/versions
@@ -1,5 +1,5 @@
 #/usr/bin/env bash
 tf=$(curl -s "https://releases.hashicorp.com/terraform/")
-match="\/terraform\/?([^\/]*)\/"
+match="[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}[^-\/]"
 [[ ${tf} =~ ${match} ]]; 
-echo "${BASH_REMATCH[1]}"
+echo "${BASH_REMATCH[0]}"

--- a/linux/terraform-azure/versions
+++ b/linux/terraform-azure/versions
@@ -1,5 +1,5 @@
 #/usr/bin/env bash
 tf=$(curl -s "https://releases.hashicorp.com/terraform/")
-match="\/terraform\/?([^\/]*)\/"
+match="[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}[^-\/]"
 [[ ${tf} =~ ${match} ]]; 
-echo "${BASH_REMATCH[1]}"
+echo "${BASH_REMATCH[0]}"

--- a/linux/terraform/versions
+++ b/linux/terraform/versions
@@ -1,5 +1,5 @@
 #/usr/bin/env bash
 tf=$(curl -s "https://releases.hashicorp.com/terraform/")
-match="\/terraform\/?([^\/]*)\/"
+match="[0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}[^-\/]"
 [[ ${tf} =~ ${match} ]]; 
-echo "${BASH_REMATCH[1]}"
+echo "${BASH_REMATCH[0]}"


### PR DESCRIPTION
Currently the regex is picking up the 0.13.0-beta1 images as the latest and ignoring the latest stable version. 

This PR updates the regex to ignore any version containing a `-` which works as Terraform adheres to SemVer. The `-` informs us that this  is a prerelease.