### PR TITLE
Use script for selecting terraform version

### DIFF
--- a/linux/terraform-azure-make/Dockerfile
+++ b/linux/terraform-azure-make/Dockerfile
@@ -6,10 +6,9 @@ RUN apt-get update \
     curl=* \
     unzip=* \
     && rm -rf /var/lib/apt/lists/*
-RUN tf=$(curl "https://releases.hashicorp.com/terraform/") && \
-    match="\/terraform\/?([^\/]*)\/" && \
-    [[ ${tf} =~ ${match}  ]] && \
-    version=${BASH_REMATCH[1]} && \
+COPY versions versions
+RUN chmod a+x ./versions && \
+    version=$(./versions) && \
     curl -O "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip" -sk && \
     unzip -j "terraform_${version}_linux_amd64.zip"
 

--- a/linux/terraform-azure-powershell/Dockerfile
+++ b/linux/terraform-azure-powershell/Dockerfile
@@ -6,12 +6,12 @@ RUN apt-get update \
     curl=* \
     unzip=* \
     && rm -rf /var/lib/apt/lists/*
-RUN tf=$(curl "https://releases.hashicorp.com/terraform/") && \
-    match="\/terraform\/?([^\/]*)\/" && \
-    [[ ${tf} =~ ${match}  ]] && \
-    version=${BASH_REMATCH[1]} && \
+COPY versions versions
+RUN chmod a+x ./versions && \
+    version=$(./versions) && \
     curl -O "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip" -sk && \
     unzip -j "terraform_${version}_linux_amd64.zip"
+    
 FROM debian:stretch-20190708-slim
 COPY --from=terraform /terraform /usr/local/bin/terraform
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/linux/terraform-azure/Dockerfile
+++ b/linux/terraform-azure/Dockerfile
@@ -6,10 +6,9 @@ RUN apt-get update \
     curl=* \
     unzip=* \
     && rm -rf /var/lib/apt/lists/*
-RUN tf=$(curl "https://releases.hashicorp.com/terraform/") && \
-    match="\/terraform\/?([^\/]*)\/" && \
-    [[ ${tf} =~ ${match}  ]] && \
-    version=${BASH_REMATCH[1]} && \
+COPY versions versions
+RUN chmod a+x ./versions && \
+    version=$(./versions) && \
     curl -O "https://releases.hashicorp.com/terraform/${version}/terraform_${version}_linux_amd64.zip" -sk && \
     unzip -j "terraform_${version}_linux_amd64.zip"
 


### PR DESCRIPTION
Currently the logic for selecting the version of terraform is duplicated across the `versions` scripts and the Dockerfile.  This PR updates the Dockerfile to use the `versions` script instead.

The side effect of this is that only terraform stable releases will be included in the image which is desired.