### PR TITLE
Update AWS images

### DIFF
--- a/linux/aws/Dockerfile
+++ b/linux/aws/Dockerfile
@@ -1,3 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.12-alpine
 
-RUN pip3 install --no-cache-dir --upgrade awscli==1.16.291
+RUN pip3 install --no-cache-dir --upgrade awscli==1.38.26
+RUN apk add --no-cache groff

--- a/linux/aws/README.md
+++ b/linux/aws/README.md
@@ -6,8 +6,8 @@ Python and various dependencies
 
 |Technology/Library|Version |
 |------------------|--------|
-|Python            |3.6     |
-|awscli            |1.16.291|
+|Python            |3.12    |
+|awscli            |1.38.26 |
 
 ## How to use
 

--- a/linux/awscli/Dockerfile
+++ b/linux/awscli/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.6-slim
+FROM python:3.12-alpine
 
-RUN pip3 install --no-cache-dir --upgrade awscli==1.16.291
+RUN pip3 install --no-cache-dir --upgrade awscli==1.38.26
+RUN apk add --no-cache groff
 
 ENTRYPOINT ["aws"]

--- a/linux/awscli/README.md
+++ b/linux/awscli/README.md
@@ -4,8 +4,8 @@ Python and various dependencies
 
 |Technology/Library|Version |
 |------------------|--------|
-|Python            |3.6     |
-|awscli            |1.16.291|
+|Python            |3.12    |
+|awscli            |1.38.26 |
 
 ## How to use
 


### PR DESCRIPTION
# What has been done
- Update images to use python3.12-alpine (later and slimmer images)
- Use latest version of the CLI
- Install groff (for help docs)
- Updated readme