### PR TITLE
Setting up dotnet 10 image.

### DIFF
--- a/linux/dotnetcore100-zip/Dockerfile
+++ b/linux/dotnetcore100-zip/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    zip=* \
+    && rm -rf /var/lib/apt/lists/*

--- a/linux/dotnetcore100-zip/README.md
+++ b/linux/dotnetcore100-zip/README.md
@@ -1,0 +1,10 @@
+# dotnetcore100-zip
+
+## Purpose
+.NET 10 SDK build image with `zip` installed for packaging artifacts.
+
+## Installed dependencies
+| Dependency | Version | Notes |
+|---|---|---|
+| .NET SDK | 10.0 | From base image `mcr.microsoft.com/dotnet/sdk:10.0` |
+| zip | distro package | Installed via `apt-get` |


### PR DESCRIPTION
This pull request introduces a new Docker image setup for building .NET 10 applications with additional support for artifact packaging using the `zip` utility. The changes include the creation of a Dockerfile and accompanying documentation.

**New Docker image for .NET 10 with zip support:**

* Added a new `Dockerfile` in `linux/dotnetcore100-zip` that uses the `.NET 10 SDK` base image and installs the `zip` utility for packaging build artifacts.

**Documentation:**

* Created a `README.md` in `linux/dotnetcore100-zip` describing the image's purpose, the installed dependencies, and their versions.